### PR TITLE
Resolve 51 add option to run file in its directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Dependent on your project, you might:
 
 ## Release Notes
 
+### 2024.3.x
+
+- Added dedicated terminal creation commands (#51)
+- `ipython.createDedicatedTerminal (ctrl+shift+i shift+c)`
+  - Create an ipython terminal linked to current active `.py` file
+- `ipython.createDedicatedTerminalInFileDir (ctrl+shift+i ctrl+shift+c)`
+  - Create an ipython terminal linked to current active `.py` with terminal
+    current directory the file's directory
+
 ### 2024.1.x
 
 - Added section auto-numbering and manual numbering option to navigator (#48)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "ipython",
     "description": "IPython integration supporting direct interactive usage and commands.",
     "icon": "md_img/icon.png",
-    "version": "2024.1.2",
+    "version": "2024.3.0",
     "publisher": "HoangKimLai",
     "repository": {
         "type": "git",
@@ -264,6 +264,16 @@
             {
                 "command": "ipython.createTerminal",
                 "key": "ctrl+shift+i c",
+                "when": "ipython.isUse"
+            },
+            {
+                "command": "ipython.createDedicatedTerminal",
+                "key": "ctrl+shift+i shift+c",
+                "when": "ipython.isUse"
+            },
+            {
+                "command": "ipython.createDedicatedTerminalInFileDir",
+                "key": "ctrl+shift+i ctrl+shift+c",
                 "when": "ipython.isUse"
             },
             {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,16 @@
             },
             {
                 "category": "IPython",
+                "command": "ipython.createDedicatedTerminal",
+                "title": "Create a Dedicated IPython Terminal for Current Active Python File"
+            },
+            {
+                "category": "IPython",
+                "command": "ipython.createDedicatedTerminalInFileDir",
+                "title": "Create a Dedicated IPython Terminal with its Current Directory the Active Python File Directory"
+            },
+            {
+                "category": "IPython",
                 "command": "ipython.runFile",
                 "title": "Run File in an IPython Terminal"
             },

--- a/src/ipython.ts
+++ b/src/ipython.ts
@@ -238,7 +238,7 @@ export async function createTerminal(
 
     // -- Create and Tag IPython Terminal
     await vscode.commands.executeCommand('python.createTerminal');
-    util.wait(500); // msec, to help with a race condition of not naming terminal
+    util.wait(1000); // msec, to help with a race condition of not naming terminal
 
     // FIXME: this is shaky, perhaps use @vscode/python-extension
     let terminal = vscode.window.terminals[vscode.window.terminals.length - 1];

--- a/src/navigate.ts
+++ b/src/navigate.ts
@@ -902,8 +902,8 @@ export class SectionTree {
  *
  * @param document containing cursor and having any section
  * @param cursor position in document
- * @returns lowest level section containing cursor if exists. Note,
- * {@link navi.Section.parent} can be used to get parent level section.
+ * @returns lowest level {@link Section} containing cursor if exists. Note,
+ * {@link Section.parent} can be used to get parent level section.
  */
 export function getSectionFrom(
     document: vscode.TextDocument,
@@ -913,6 +913,20 @@ export function getSectionFrom(
     if (tree === undefined) {
         console.error('getSectionFrom: failed to retrieve cache');
         return;
+    }
+
+    if (!tree.root.length) {  // .py without any section
+        let header = path.basename(document.fileName);
+        let lastLine = document.lineCount - 1;
+        let lastPosition = document.lineAt(lastLine).rangeIncludingLineBreak.end;
+        let range = new vscode.Range(
+            new vscode.Position(0, 0),
+            lastPosition,
+        )
+        return new Section(
+            range,
+            header,
+        )
     }
 
     let section = tree.getSection(cursor);


### PR DESCRIPTION
Closes #51, #52

- `ipython.createDedicatedTerminal (ctrl+shift+i shift+c)`
  - Create an ipython terminal linked to current active `.py` file
- `ipython.createDedicatedTerminalInFileDir (ctrl+shift+i ctrl+shift+c)`
  - Create an ipython terminal linked to current active `.py` with terminal
    current directory the file's directory
- Revision to v2024.3.0